### PR TITLE
Add Wikipedia search button to highlight menu

### DIFF
--- a/mobile/components/SelectionMenu.tsx
+++ b/mobile/components/SelectionMenu.tsx
@@ -4,6 +4,7 @@ import {
   TouchableOpacity,
   View,
   useWindowDimensions,
+  Linking,
 } from "react-native"
 import Clipboard from "@react-native-clipboard/clipboard"
 import uuid from "react-native-uuid"
@@ -14,6 +15,7 @@ import { TrashIcon } from "../icons/TrashIcon"
 import { HighlightColorPicker } from "./HighlightColorPicker"
 import { useColorTheme } from "../hooks/useColorTheme"
 import { CopyIcon } from "../icons/CopyIcon"
+import { WikipediaSearchIcon } from "../icons/WikipediaSearchIcon"
 import type { UUID } from "node:crypto"
 
 type Props = {
@@ -37,7 +39,7 @@ export function SelectionMenu({
   const { background } = useColorTheme()
   const dispatch = useAppDispatch()
 
-  const numIcons = existingHighlight ? 7 : 6
+  const numIcons = existingHighlight ? 8 : 7
   const panelWidth = numIcons * (24 + 16)
   const leftOffset = Math.max(
     16, // Minimum left padding
@@ -87,6 +89,35 @@ export function SelectionMenu({
           }}
         >
           <CopyIcon />
+        </Pressable>
+        <Pressable
+          style={styles.searchButton}
+          onPress={() => {
+            const text = (
+              existingHighlight?.locator ?? locator
+            ).text?.highlight?.toString() ?? ""
+            if (text) {
+              const query = encodeURIComponent(text)
+              const appUrl =
+                `wikipedia://en.wikipedia.org/wiki/Special:Search?search=${query}`
+              const webUrl =
+                `https://en.wikipedia.org/wiki/Special:Search?search=${query}`
+              Linking.canOpenURL(appUrl)
+                .then((supported) => {
+                  if (supported) {
+                    Linking.openURL(appUrl)
+                  } else {
+                    Linking.openURL(webUrl)
+                  }
+                })
+                .catch(() => {
+                  Linking.openURL(webUrl)
+                })
+            }
+            onClose()
+          }}
+        >
+          <WikipediaSearchIcon />
         </Pressable>
         {existingHighlight && (
           <Pressable
@@ -143,6 +174,11 @@ const styles = StyleSheet.create({
     borderColor: "#AAA",
   },
   copyButton: {
+    width: 24,
+    height: 24,
+    margin: 8,
+  },
+  searchButton: {
     width: 24,
     height: 24,
     margin: 8,

--- a/mobile/icons/WikipediaSearchIcon.tsx
+++ b/mobile/icons/WikipediaSearchIcon.tsx
@@ -1,0 +1,24 @@
+import { Path, Svg } from "react-native-svg"
+import { useColorTheme } from "../hooks/useColorTheme"
+
+export function WikipediaSearchIcon() {
+  const { foreground } = useColorTheme()
+  return (
+    <Svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+      <Path
+        d="M11 2a9 9 0 016.32 15.32l4.69 4.69-1.41 1.41-4.69-4.69A9 9 0 1111 2z"
+        stroke={foreground}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <Path
+        d="M11 6a5 5 0 100 10 5 5 0 000-10z"
+        stroke={foreground}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  )
+}


### PR DESCRIPTION
## Summary
- add WikipediaSearchIcon
- expand SelectionMenu to include a Wikipedia search option
- try opening the Wikipedia app first and fall back to the browser

## Testing
- `yarn check:lint` *(fails: node_modules missing)*
- `yarn check:format` *(fails: node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_68697b5979b0832a92c88b210d9bc6d3